### PR TITLE
Add new map component

### DIFF
--- a/components.ts
+++ b/components.ts
@@ -2,6 +2,7 @@
  * Components
  */
 import Image from './src/components/image'
+import Map from './src/components/map/map'
 import Seo from './src/components/seo'
 
-export { Image, Seo }
+export { Image, Map, Seo }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
   "author": "James Dinsdale <hi@molovo.co>",
   "license": "MIT",
   "dependencies": {
+    "@types/google-map-react": "^2.1.5",
+    "@types/google.maps": "^3.48.3",
     "@types/react-helmet": "^6.1.5",
+    "@types/supercluster": "^7.1.0",
     "atob": "^2.1.2",
     "gatsby": "^4.6.0",
     "gatsby-plugin-image": "2.3.0",
     "gatsby-source-prismic": "5.2.3",
+    "google-map-react": "^2.1.10",
     "react-helmet": "^6.1.0",
-    "reinspect": "^1.1.0"
+    "reinspect": "^1.1.0",
+    "supercluster": "^7.1.4"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -158,8 +158,9 @@ const Map = ({
                       className="cluster-marker"
                       onClick={() => {
                         const expansionZoom = Math.min(
-                          supercluster?.getClusterExpansionZoom(cluster.id) ||
-                            5,
+                          supercluster?.getClusterExpansionZoom(
+                            cluster.id as number
+                          ) || 5,
                           20
                         )
                         mapRef.current?.setZoom(expansionZoom)

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -37,7 +37,7 @@ const Map = ({
   const mapsRef = useRef<typeof google.maps>()
 
   const [zoom, setZoom] = useState<number>(initialZoom)
-  const [bounds, setBounds] = useState<Bounds>(null)
+  const [bounds, setBounds] = useState<Bounds>([0, 0, 0, 0])
 
   const { clusters, supercluster } = useSupercluster(
     markers,
@@ -106,7 +106,7 @@ const Map = ({
     <div id="map" className={`map ${className}`}>
       <GoogleMapReact
         bootstrapURLKeys={{
-          key: process.env.GATSBY_GOOGLE_MAPS_API_KEY,
+          key: process.env.GATSBY_GOOGLE_MAPS_API_KEY as string,
         }}
         center={{
           lat: center.lat,

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -1,0 +1,192 @@
+import React, {
+  ReactElement,
+  PropsWithChildren,
+  useCallback,
+  useRef,
+  useState,
+} from 'react'
+import GoogleMapReact from 'google-map-react'
+import { Bounds, LatLng, MarkerProps } from './types'
+import useSupercluster from './useSupercluster'
+import { AnyProps, PointFeature } from 'supercluster'
+import Marker from './marker'
+import googleMapReact from 'google-map-react'
+
+interface Props extends PropsWithChildren<{}> {
+  center: LatLng
+  markers: MarkerProps[]
+  radius?: number
+  initialZoom?: number
+  useClustering?: boolean
+  className?: string
+  markerIcon?: ReactElement
+  clusterMarkerIcon?: ReactElement
+}
+
+const Map = ({
+  center,
+  markers = [],
+  radius = 25,
+  initialZoom = 10,
+  useClustering = false,
+  className = '',
+  markerIcon = undefined,
+  clusterMarkerIcon = undefined,
+}: Props) => {
+  const mapRef = useRef<google.maps.Map>()
+  const mapsRef = useRef<typeof google.maps>()
+
+  const [zoom, setZoom] = useState<number>(initialZoom)
+  const [bounds, setBounds] = useState<Bounds>(null)
+
+  const { clusters, supercluster } = useSupercluster(
+    markers,
+    bounds,
+    zoom,
+    radius
+  )
+
+  // Return map bounds based on list of places
+  const getMapBounds = (places: MarkerProps[]) => {
+    if (!mapsRef.current) {
+      return
+    }
+
+    const bounds = new mapsRef.current.LatLngBounds()
+    places.forEach(place => {
+      bounds.extend(place.center)
+    })
+    return bounds
+  }
+
+  const bindResizeListener = (
+    bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral
+  ) => {
+    if (!mapsRef.current || !mapRef.current) {
+      return
+    }
+
+    mapsRef.current.event.addDomListenerOnce(mapRef.current, 'idle', () => {
+      if (!mapsRef.current || !mapRef.current) {
+        return
+      }
+
+      mapsRef.current.event.addDomListener(window, 'resize', () => {
+        if (!mapRef.current) {
+          return
+        }
+
+        mapRef.current.fitBounds(bounds)
+      })
+    })
+  }
+
+  // Fit map to its bounds after the api is loaded
+  const apiIsLoaded = useCallback((map, maps, places: MarkerProps[]) => {
+    mapRef.current = map
+    mapsRef.current = maps
+
+    if (places.length === 0 || places.length === 1) {
+      //Doesn't play nicely with zero or one items
+      return
+    }
+
+    // Get bounds by our places
+    const bounds = getMapBounds(places)
+
+    if (bounds) {
+      // Fit map to bounds
+      map.fitBounds(bounds)
+      // Bind the resize listener
+      bindResizeListener(bounds)
+    }
+  }, [])
+
+  return (
+    <div id="map" className={`map ${className}`}>
+      <GoogleMapReact
+        bootstrapURLKeys={{
+          key: process.env.GATSBY_GOOGLE_MAPS_API_KEY,
+        }}
+        center={{
+          lat: center.lat,
+          lng: center.lng,
+        }}
+        defaultZoom={initialZoom}
+        // onChildClick={onChildClickCallback}
+        yesIWantToUseGoogleMapApiInternals
+        onGoogleApiLoaded={({ map, maps }) => {
+          apiIsLoaded(map, maps, markers)
+        }}
+        onChange={({
+          zoom,
+          bounds,
+        }: {
+          zoom: number
+          bounds: googleMapReact.Bounds
+        }) => {
+          setZoom(zoom)
+          setBounds([
+            bounds.nw.lng,
+            bounds.se.lat,
+            bounds.se.lng,
+            bounds.nw.lat,
+          ])
+        }}
+      >
+        {useClustering
+          ? clusters.map((cluster: PointFeature<AnyProps>, index) => {
+              const [longitude, latitude] = cluster.geometry.coordinates
+              const { cluster: isCluster, point_count: pointCount } =
+                cluster.properties
+
+              return (
+                <Marker
+                  key={index}
+                  lat={latitude}
+                  lng={longitude}
+                  text={pointCount}
+                  icon={
+                    isCluster && clusterMarkerIcon
+                      ? clusterMarkerIcon
+                      : markerIcon
+                  }
+                  isCluster={isCluster}
+                >
+                  {isCluster && (
+                    <div
+                      className="cluster-marker"
+                      onClick={() => {
+                        const expansionZoom = Math.min(
+                          supercluster?.getClusterExpansionZoom(cluster.id) ||
+                            5,
+                          20
+                        )
+                        mapRef.current?.setZoom(expansionZoom)
+                        mapRef.current?.panTo({
+                          lat: latitude,
+                          lng: longitude,
+                        })
+                      }}
+                    >
+                      {pointCount}
+                    </div>
+                  )}
+                </Marker>
+              )
+            })
+          : markers.map((marker, index) => (
+              <Marker
+                key={index}
+                lat={marker.center.lat}
+                lng={marker.center.lng}
+                text={marker.label}
+                icon={markerIcon}
+              />
+            ))}
+      </GoogleMapReact>
+    </div>
+  )
+}
+
+export default Map

--- a/src/components/map/marker.tsx
+++ b/src/components/map/marker.tsx
@@ -13,7 +13,7 @@ const Marker = ({
   lat,
   lng,
   text,
-  icon = null,
+  icon = undefined,
   isCluster = false,
 }: Props) => {
   return (

--- a/src/components/map/marker.tsx
+++ b/src/components/map/marker.tsx
@@ -1,0 +1,27 @@
+import React, { PropsWithChildren, ReactElement } from 'react'
+
+interface Props extends PropsWithChildren<{}> {
+  lat: number
+  lng: number
+  text: string
+  isCluster?: boolean
+  icon?: ReactElement
+}
+
+const Marker = ({
+  children,
+  lat,
+  lng,
+  text,
+  icon = null,
+  isCluster = false,
+}: Props) => {
+  return (
+    <div className={`map__marker ${isCluster ? 'map__marker--cluster' : ''}`}>
+      {icon && icon}
+      {children}
+    </div>
+  )
+}
+
+export default Marker

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -1,0 +1,8 @@
+export type LatLng = google.maps.LatLngLiteral
+
+export type Bounds = [number, number, number, number]
+
+export interface MarkerProps {
+  center: LatLng
+  label: string
+}

--- a/src/components/map/useSupercluster.ts
+++ b/src/components/map/useSupercluster.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Supercluster, { AnyProps, PointFeature } from 'supercluster'
+import { Bounds, MarkerProps } from './types'
+
+const useSupercluster = (
+  markers: MarkerProps[] = [],
+  bounds: Bounds,
+  zoom: number = 10,
+  radius: number = 25,
+) => {
+  const supercluster = useRef<Supercluster>(null)
+  const [clusters, setClusters] = useState([])
+
+  const formatGeopoint = useCallback(
+    item =>
+      ({
+        type: 'Feature',
+        properties: {
+          cluster: false,
+          store: item,
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [item.center.lng, item.center.lat],
+        },
+      } as PointFeature<AnyProps>),
+    [],
+  )
+
+  useEffect(() => {
+    if (markers.length === 0) {
+      supercluster.current = null
+      setClusters([])
+    } else {
+      supercluster.current = new Supercluster({
+        radius,
+        maxZoom: 20,
+      })
+      supercluster.current.load(markers.map(formatGeopoint))
+      if (bounds && zoom) {
+        setClusters(supercluster.current.getClusters(bounds, zoom))
+      }
+    }
+  }, [markers, formatGeopoint, setClusters, bounds, zoom])
+
+  return { clusters, supercluster: supercluster.current }
+}
+
+export default useSupercluster

--- a/src/components/map/useSupercluster.ts
+++ b/src/components/map/useSupercluster.ts
@@ -6,10 +6,10 @@ const useSupercluster = (
   markers: MarkerProps[] = [],
   bounds: Bounds,
   zoom: number = 10,
-  radius: number = 25,
+  radius: number = 25
 ) => {
   const supercluster = useRef<Supercluster>(null)
-  const [clusters, setClusters] = useState([])
+  const [clusters, setClusters] = useState<PointFeature<AnyProps>[]>([])
 
   const formatGeopoint = useCallback(
     item =>
@@ -24,7 +24,7 @@ const useSupercluster = (
           coordinates: [item.center.lng, item.center.lat],
         },
       } as PointFeature<AnyProps>),
-    [],
+    []
   )
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,13 @@
     querystring "^0.2.0"
     strip-ansi "^6.0.0"
 
+"@googlemaps/js-api-loader@^1.7.0":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.13.10.tgz#499cb58b9dcf8d29101d6d113650b27a55c70ae5"
+  integrity sha512-11AF8SdXca1+trN7kDYiPqwxcjQjet/e/A20PPR2hMHQIZ0ktxd4VsqbsSDLj1BZW1bke0FnZ4zY0KYmgWZ9cg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 "@graphql-tools/batch-execute@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-7.1.2.tgz#35ba09a1e0f80f34f1ce111d23c40f039d4403a0"
@@ -1319,6 +1326,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@mapbox/point-geometry@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
 
 "@microsoft/fetch-event-source@2.0.1":
   version "2.0.1"
@@ -2022,6 +2034,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/geojson@*":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+
 "@types/get-port@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
@@ -2042,6 +2059,18 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/google-map-react@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/google-map-react/-/google-map-react-2.1.5.tgz#2c477abffa33ae97e8bb893891892b97c5dc9135"
+  integrity sha512-79FeuNnqPbLNWLChfcqL6exS9oPfvzPkxSxdry12ueVYRaGDGWze4TjV6cRTZP4QRZxtZBTLtDqly2zeD5VEoQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/google.maps@^3.48.3":
+  version "3.48.3"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.48.3.tgz#c554fbd7076c75fdd82dbae0ff3d541f67f5c599"
+  integrity sha512-JQuLWAEXDorNfarQy22WbIezbPKhLnsTBnDw25vyg61USZLTK8KqE1glNyASKn2v2mUOcEIWFMNHX5hNzjuw/g==
 
 "@types/http-cache-semantics@*":
   version "4.0.1"
@@ -2171,6 +2200,13 @@
   integrity sha512-3TC+S3H5RwnJmLYMHrcdfNjz/CaApKmujjY9b6PU/pE6n0qfooi99YqXGWoW8frU9EWYj/XTI35Pzxa+ThAZ5Q==
   dependencies:
     "@types/node" "*"
+
+"@types/supercluster@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/supercluster/-/supercluster-7.1.0.tgz#67b7466c93a7d25b6e79a3c7cad885a79420aeb4"
+  integrity sha512-6JapQ2GmEkH66r23BK49I+u6zczVDGTtiJEVvKDYZVSm/vepWaJuTq6BXzJ6I4agG5s8vA1KM7m/gXWDg03O4Q==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/tmp@^0.0.33":
   version "0.0.33"
@@ -4542,7 +4578,7 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5597,6 +5633,16 @@ globby@^11.0.3, globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+google-map-react@^2.1.10:
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/google-map-react/-/google-map-react-2.1.10.tgz#16b5b699f257d6008dc9333d0bbbf1ab5b31fa42"
+  integrity sha512-cqW2EcygYqF26inp5liM/pAcCwOGXB9LW32oGwf931Iuq8tnasCpyEtq87G+RyQCKCo2P8/QyV+MGHuc7r9AEg==
+  dependencies:
+    "@googlemaps/js-api-loader" "^1.7.0"
+    "@mapbox/point-geometry" "^0.1.0"
+    eventemitter3 "^4.0.4"
+    prop-types "^15.7.2"
+
 got@^11.8.2, got@^11.8.3:
   version "11.8.3"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
@@ -6557,6 +6603,11 @@ jsuri@^1.3.1:
   dependencies:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
+
+kdbush@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
+  integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -9300,6 +9351,13 @@ sudo-prompt@^8.2.0:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-8.2.5.tgz#cc5ef3769a134bb94b24a631cc09628d4d53603e"
   integrity sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==
+
+supercluster@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.4.tgz#6762aabfd985d3390b49f13b815567d5116a828a"
+  integrity sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==
+  dependencies:
+    kdbush "^3.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Provides a simple wrapper to set up a Google Map with minimal boilerplate.

To use, first add `GATSBY_GOOGLE_MAPS_API_KEY` to `.env`, and then drop into your component:
```
import { Map } from '@superrb/gatsby-addons/components'

const MyMap = () => (
  <Map
    center={{ lat: 50.78749329999999, lng: -0.9749420000000001 }}
    markers={[
      {
        label: 'Superrb',
        center: {
          lat: 50.78749329999999,
          lng: -0.9749420000000001
      }
    ]}
    initialZoom={15}
    useClustering={false}
    markerIcon={<AnyComponent />}
    clusterMarkerIcon={<AnyComponent />}
  />
)
```